### PR TITLE
replace deprecated React.PropTypes usage; Import prop-types instead

### DIFF
--- a/src/redux-form/createInputCreator.js
+++ b/src/redux-form/createInputCreator.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { View } from 'react-native'
+import PropTypes from 'prop-types'
 import { FormGroup, Label } from '../../index'
 import styled from 'styled-components/native'
 import defaultTheme from '../Theme'
@@ -30,7 +31,7 @@ const render = renderComponent => props => {
 }
 
 
-const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, PropTypes = {}, defaultProps = {}) => {
+const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, PropTypesOverrides = {}, defaultProps = {}) => {
   const Component = render(renderFunction)
   Component.displayName = name
 
@@ -42,11 +43,11 @@ const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, Pro
 
   FieldWrapper.displayName = 'FieldWrapper'
   FieldWrapper.PropTypes = Object.assign({
-    border: React.PropTypes.bool,
-    inlineLabel: React.PropTypes.bool,
-    label: React.PropTypes.string.isRequired,
-    name: React.PropTypes.string.isRequired
-  }, PropTypes)
+    border: PropTypes.bool,
+    inlineLabel: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }, PropTypesOverrides)
   FieldWrapper.defaultProps = Object.assign({
     border: FormGroup.defaultProps.border,
     inlineLabel: FormGroup.defaultProps.inlineLabel


### PR DESCRIPTION
The attempt [here](https://github.com/jdcc2/react-native-clean-form/commit/8bd267d9c939cbcb347cf5a49e5e13fafe824786) to fix the problem is great.
There seems to be other places which needs to be fixed as well and this PR makes the fix complete.